### PR TITLE
Fix: Compatibility with Cabal 2.3.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 import Distribution.Simple
 import Distribution.Simple.Setup
 import Distribution.PackageDescription
@@ -26,7 +28,11 @@ main = defaultMainWithHooks simpleUserHooks {
   where
     defaultPostConf :: Args -> ConfigFlags -> PackageDescription -> LocalBuildInfo -> IO ()
     defaultPostConf args flags pkgdescr lbi = do
+#if MIN_VERSION_Cabal(2,3,0)
       libdir_ <- getDbProgramOutput (fromFlag (configVerbosity flags))
+#else
+      libdir_ <- rawSystemProgramStdoutConf (fromFlag (configVerbosity flags))
+#endif
                      ghcProgram (withPrograms lbi) ["--print-libdir"]
       let libdir = reverse $ dropWhile isSpace $ reverse libdir_
 

--- a/Setup.hs
+++ b/Setup.hs
@@ -26,7 +26,7 @@ main = defaultMainWithHooks simpleUserHooks {
   where
     defaultPostConf :: Args -> ConfigFlags -> PackageDescription -> LocalBuildInfo -> IO ()
     defaultPostConf args flags pkgdescr lbi = do
-      libdir_ <- rawSystemProgramStdoutConf (fromFlag (configVerbosity flags))
+      libdir_ <- getDbProgramOutput (fromFlag (configVerbosity flags))
                      ghcProgram (withPrograms lbi) ["--print-libdir"]
       let libdir = reverse $ dropWhile isSpace $ reverse libdir_
 

--- a/ghc-paths.cabal
+++ b/ghc-paths.cabal
@@ -13,7 +13,7 @@ cabal-version: >= 1.6
 build-type: Custom
 
 custom-setup
-        setup-depends: base >= 3 && < 5, Cabal >= 1.6 && <2.3, directory
+        setup-depends: base >= 3 && < 5, Cabal >= 1.6 && <2.4, directory
 
 library
         build-depends: base >= 3 && < 5

--- a/ghc-paths.cabal
+++ b/ghc-paths.cabal
@@ -1,5 +1,5 @@
 name: ghc-paths
-version: 0.1.0.10
+version: 0.1.0.11
 license: BSD3
 license-file: LICENSE
 copyright: (c) Simon Marlow


### PR DESCRIPTION
I am not a guru version bounds bumper, but I thought it does not hurt anyone if I take a shot at this. I checked that it builds against the newest and the oldest `ghc` I have, but nevertheless do review if you consider merging.

#### Before:

* Build against `ghc-7.8.4` & `Cabal-1.18.1.5`: **Yes**.
* Build against `ghc-8.6.0.20180714` & `Cabal-2.3.0.0`: **No**.

#### After:

* Build against `ghc-7.8.4` & `Cabal-1.18.1.5`: **Yes**.
* Build against `ghc-8.6.0.20180714` & `Cabal-2.3.0.0`: **Yes**.
