### PR TITLE
Allow Cabal 2.4.

### DIFF
--- a/ghc-paths.cabal
+++ b/ghc-paths.cabal
@@ -13,7 +13,7 @@ cabal-version: >= 1.6
 build-type: Custom
 
 custom-setup
-        setup-depends: base >= 3 && < 5, Cabal >= 1.6 && <2.4, directory
+        setup-depends: base >= 3 && < 5, Cabal >= 1.6 && <2.5, directory
 
 library
         build-depends: base >= 3 && < 5


### PR DESCRIPTION
ghc-paths is already 2.4 ready; this is just a matter of bounds
gardening.

I tested this by building a complicated project with many doctests
using ghc-paths HEAD + Cabal 2.4 and it worked fine.

After this is merged, a release would be handy, please.