### PR TITLE
Allow Cabal-3.2

### DIFF
--- a/ghc-paths.cabal
+++ b/ghc-paths.cabal
@@ -13,7 +13,7 @@ cabal-version: >= 1.6
 build-type: Custom
 
 custom-setup
-        setup-depends: base >= 3 && < 5, Cabal >= 1.6 && <3.1, directory
+        setup-depends: base >= 3 && < 5, Cabal >= 1.6 && <3.3, directory
 
 library
         build-depends: base >= 3 && < 5


### PR DESCRIPTION
I already made a revision, https://hackage.haskell.org/package/ghc-paths-0.1.0.12/revisions/, so no action is required after the merge.