### PR TITLE
Bump the Cabal version to 3.4 and require 1.8 minimum in the project

### DIFF
--- a/ghc-paths.cabal
+++ b/ghc-paths.cabal
@@ -9,11 +9,11 @@ stability: stable
 synopsis: Knowledge of GHC's installation directories
 description: Knowledge of GHC's installation directories
 category: Development
-cabal-version: >= 1.6
+cabal-version: >= 1.8
 build-type: Custom
 
 custom-setup
-        setup-depends: base >= 3 && < 5, Cabal >= 1.6 && <3.3, directory
+        setup-depends: base >= 3 && < 5, Cabal >= 1.6 && <3.4, directory
 
 library
         build-depends: base >= 3 && < 5


### PR DESCRIPTION
For Haddock's transition to 9.0, we need to bump the accepted Cabal version to 3.4.  
Additionally, a warning requiring 1.8 in the cabal-version stanza is fixed:

```
Warning: /home/hecate/Contrib/ghc-paths/ghc-paths.cabal:19:36: version
operators used. To use version operators the package needs to specify at least
'cabal-version: >= 1.8'.
Warning: /home/hecate/Contrib/ghc-paths/ghc-paths.cabal:16:36: version
operators used. To use version operators the package needs to specify at least
'cabal-version: >= 1.8'.
Warning: /home/hecate/Contrib/ghc-paths/ghc-paths.cabal:16:57: version
operators used. To use version operators the package needs to specify at least
'cabal-version: >= 1.8'.
```