### PR TITLE
Bump CI to GHC 9.12.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.2
             compilerKind: ghc
             compilerVersion: 9.10.2

--- a/ghc-paths.cabal
+++ b/ghc-paths.cabal
@@ -1,6 +1,6 @@
 name: ghc-paths
 version: 0.1.0.12
-x-revision: 6
+x-revision: 7
 license: BSD3
 license-file: LICENSE
 copyright: (c) Simon Marlow
@@ -15,6 +15,7 @@ build-type: Custom
 
 
 tested-with:
+  GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
@@ -31,7 +32,7 @@ tested-with:
 custom-setup
         setup-depends:
             base  >= 3   && < 5
-          , Cabal >= 1.6 && < 3.13
+          , Cabal >= 1.6 && < 3.15
           , directory
 
 library


### PR DESCRIPTION
Turns out that Setup.hs is compatible with Cabal-3.14.

https://github.com/simonmar/ghc-paths/actions/runs/14909711844/job/41880774975?pr=34#step:18:42
> ```
> [setup]
> ├─ Cabal-3.14.1.0
> │   ├─ Cabal-syntax-3.14.1.0
> ```

A revision has already been made: https://hackage.haskell.org/package/ghc-paths-0.1.0.12/revision/7.cabal

But the revision is not on `master`, this PR will fix this.